### PR TITLE
Total key counts, storms fixes

### DIFF
--- a/c/dungeon_info.c
+++ b/c/dungeon_info.c
@@ -71,7 +71,7 @@ void draw_dungeon_info(z64_disp_buf_t *db)
         padding +
         (8 * font_sprite.tile_w) + // dungeon names
         padding +
-        (7 * (icon_size + padding)); // skull, skull count, key, key count, bk, map, compass
+        (8 * (icon_size + padding)); // skull, skull count, key, unused key count, total key count, bk, map, compass
     int bg_height = padding + (dungeon_count * (icon_size + padding));
     int bg_left = (Z64_SCREEN_WIDTH - bg_width) / 2;
     int bg_top = (Z64_SCREEN_HEIGHT - bg_height) / 2;
@@ -183,12 +183,17 @@ void draw_dungeon_info(z64_disp_buf_t *db)
         if (!d->has_keys)
             continue;
 
-        int8_t keys = z64_file.dungeon_keys[d->index];
-        if (keys < 0)
-            keys = 0;
+        int8_t current_keys = z64_file.dungeon_keys[d->index];
+        if (current_keys < 0)
+            current_keys = 0;
 
-        char count[2] = "0";
-        count[0] += (keys % 10);
+        int8_t total_keys = z64_file.scene_flags[d->index].unk_00_ >> 0x10;
+        if (total_keys < 0)
+            total_keys = 0;
+
+        char count[5] = "0(0)";
+        count[0] += (current_keys % 10);
+        count[2] += (total_keys % 10);
         int top = start_top + ((icon_size + padding) * i) + 1;
         text_print(count, left, top);
     }

--- a/c/item_effects.c
+++ b/c/item_effects.c
@@ -1,0 +1,11 @@
+#include "item_effects.h"
+
+void give_small_key()
+{
+    int8_t dungeon_id = z64_file.minimap_index;
+    int8_t current_keys = z64_file.dungeon_keys[dungeon_id] > 0 ? z64_file.dungeon_keys[dungeon_id] : 0;
+    z64_file.dungeon_keys[dungeon_id] = current_keys + 1;
+    uint32_t flag = z64_file.scene_flags[dungeon_id].unk_00_;
+    int8_t total_keys = flag >> 0x10;
+    z64_file.scene_flags[dungeon_id].unk_00_ = (flag & 0x0000FFFF) | ((total_keys + 1) << 0x10);
+}

--- a/c/item_effects.h
+++ b/c/item_effects.h
@@ -1,0 +1,8 @@
+#ifndef ITEM_EFFECTS_H
+#define ITEM_EFFECTS_H
+
+#include "z64.h"
+
+void give_small_key();
+
+#endif

--- a/src/hacks.asm
+++ b/src/hacks.asm
@@ -68,6 +68,21 @@ Gameplay_InitSkybox:
 @@after_chest_speed_check:
 
 ;==================================================================================================
+; Song of Storms Effect Trigger Changes
+;==================================================================================================
+; Allow a storm to be triggered with the song in any environment
+; Replaces: lui     t5, 0x800F
+;           lbu     t5, 0x1648(t5)
+.orga 0xE6BF4C
+    li      t5, 0
+    nop
+
+; Remove the internal cooldown between storm effects (to open grottos, grow bean plants...)
+; Replaces: bnez     at, 0x80AECC6C
+.orga 0xE6BEFC
+    nop
+
+;==================================================================================================
 ; Handle total small key count for the dungeon info menu
 ;==================================================================================================
 ; Replaces:

--- a/src/hacks.asm
+++ b/src/hacks.asm
@@ -66,3 +66,29 @@ Gameplay_InitSkybox:
     nop
 .skip 4 * 24
 @@after_chest_speed_check:
+
+;==================================================================================================
+; Handle total small key count for the dungeon info menu
+;==================================================================================================
+; Replaces:
+;   lui     t0, 0x8012                 # t0 = 80120000
+;   addiu   t0, t0, 0xA5D0             # t0 = 8011A5D0
+;   lhu     t9, 0x1402(t0)             # 8011B9D2
+;   addiu   t1, r0, 0x0001             # t1 = 00000001
+;   addiu   v0, r0, 0x00FF             # v0 = 000000FF
+;   addu    v1, t0, t9
+;   lb      a0, 0x00BC(v1)             # 000000BC
+;   bgez    a0, lbl_80070198
+;   addiu   t7, a0, 0x0001             # t7 = 00000001
+;   sb      t1, 0x00BC(v1)             # 000000BC
+.orga 0xAE60C8 ; In Memory: 0x80070168
+    nop
+    jal     give_small_key
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop
+    nop


### PR DESCRIPTION
Add total key count to dungeon info menu:

- Allows you to track goals:
  - Open X Small Key Chests
  - Obtain All X Small Keys

- Intercepts the `Item_Give` code here: https://github.com/zeldaret/oot/blob/9c6461751d81191a94c45e2cf2cf654c583624e8/src/code/z_parameter.c#L1429

Fix song of storms bug in domain and sfm