### PR TITLE
Bonko Quest

### DIFF
--- a/scripts/Patches.py
+++ b/scripts/Patches.py
@@ -407,6 +407,11 @@ def patch_rom(rom:Rom, options):
         ]
         patch_files(rom, mq_scenes)
 
+    # Bonk One Hit KO
+    if options['bonko']:
+        rom.write_int32(rom.sym('CFG_DEADLY_BONKS'), 1)
+        rom.write_int16(rom.sym('CFG_BONK_DAMAGE'), 0xFFFE)
+
     # Load Message and Shop Data
     messages = read_messages(rom)
 

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -17,6 +17,7 @@ parser.add_argument('--compile-c', action='store_true', help="Recompile C module
 parser.add_argument('--dump-obj', action='store_true', help="Dumps extra object info for debugging purposes. Does nothing without --compile-c")
 parser.add_argument('--diff-only', action='store_true', help="Creates diff output without running armips")
 parser.add_argument('--mq', action='store_true', help="Patches Beta Quest with Master Quest dungeons")
+parser.add_argument('--bonko', action='store_true', help="Patches Beta Quest with Bonk One Hit KO")
 
 args = parser.parse_args()
 pj64_sym_path = args.pj64sym
@@ -24,6 +25,7 @@ compile_c = args.compile_c
 dump_obj = args.dump_obj
 diff_only = args.diff_only
 mq_enabled = args.mq
+bonko = args.bonko
 
 scripts_dir = os.path.dirname(os.path.realpath(__file__))
 root_dir = os.path.join(scripts_dir, '..')
@@ -123,7 +125,7 @@ if pj64_sym_path:
 
 # Apply python patches
 rom = Rom('roms/port.z64')
-patch_rom(rom, { 'mq_enabled': mq_enabled })
+patch_rom(rom, { 'mq_enabled': mq_enabled, 'bonko': bonko })
 rom.write_to_file('roms/port.z64')
 
 with open('roms/port.z64', 'r+b') as stream:

--- a/src/bonk.asm
+++ b/src/bonk.asm
@@ -1,0 +1,181 @@
+CFG_DEADLY_BONKS:
+    .word 0x00000000
+CFG_BONK_DAMAGE:
+    .halfword 0x0000
+.align 8
+
+
+BONK_LAST_FRAME:
+    addiu   sp, sp, -0x18
+    sw      ra, 0x10($sp)
+
+    ; displaced code
+    or      a0, s0, $zero
+    jal     0x8039BD60  ; func_80838178, static location as part of player overlay
+    nop
+
+    ; Bonk damage enabled
+    lw      t0, CFG_DEADLY_BONKS
+    beqz    t0, @@return_bonk_frame
+    nop
+    ; Set player health to zero
+    jal     APPLY_BONK_DAMAGE
+    nop
+
+@@return_bonk_frame:
+    lw      ra, 0x10($sp)
+    jr      ra
+    addiu   sp, sp, 0x18
+
+
+SET_BONK_FLAG:
+    ; displaced code
+    or      a0, s0, $zero
+    addiu   a1, $zero, 0x00FF
+
+    ; Bonk damage enabled
+    lw      t0, CFG_DEADLY_BONKS
+    beqz    t0, @@return_bonk_flag
+    nop
+
+    ; set flag
+    lbu     t0, 0x0682(s0)   ; Player state3 flag 4
+    ori     t1, t0, 0x0010
+    sb      t1, 0x0682(s0)
+
+@@return_bonk_flag:
+    jr      ra
+    nop
+
+
+CHECK_FOR_BONK_CANCEL:
+    addiu   sp, sp, -0x18
+    sw      ra, 0x10($sp)
+
+    ; displaced code
+    addiu   $at, $zero, 0x0002
+    lui     t1, 0x8012
+
+    ; Bonk damage enabled
+    lw      t8, CFG_DEADLY_BONKS
+    beqz    t8, @@return_bonk_check
+    nop
+
+    ; Check if bonk flag was set and
+    ; bonk animation flag (??) was cleared
+    lbu     t8, 0x0682(s0)   ; Player state3 flag 4
+    andi    t3, t8, 0x0010
+    beqz    t3, @@return_bonk_check
+    nop
+    lh      t3, 0x0840(s0)   ; this->unk_850
+    bnez    t3, @@return_bonk_check
+    nop
+    jal     APPLY_BONK_DAMAGE
+    nop
+
+@@return_bonk_check:
+    lw      ra, 0x10($sp)
+    jr      ra
+    addiu   sp, sp, 0x18
+
+
+APPLY_BONK_DAMAGE:
+    ; Unset bonk kill flag
+    lbu     t8, 0x0682(s0)   ; Player state3 flag 4
+    andi    t3, t8, 0xFFEF
+    sb      t3, 0x0682(s0)
+
+    ; Set player health to zero
+    lui     t8, 0x8012       ; Save Context (upper half)
+    addiu   t8, t8, 0xA5D0   ; Save Context (lower half)
+    lh      t3, 0x13C8(t8)   ; Nayru's Love Timer, range 0 - 1200
+    bnez    t3, @@return_bonk
+    nop
+    lh      t3, CFG_BONK_DAMAGE
+    bltz    t3, @@bonks_kill
+    lh      t4, 0x30(t8)     ; Player Health
+    lbu     t7, 0x3D(t8)     ; check if player has double defense
+    beq     t7, zero, @@normal_defense
+    nop
+    sra     t3, t3, 1        ; halve damage from bonk
+    sll     t3, t3, 0x10
+    sra     t3, t3, 0x10
+    
+@@normal_defense:
+    sub     t4, t4, t3
+    bltz    t4, @@bonks_kill
+    nop
+    sh      t4, 0x30(t8)
+    b       @@cmg_entrance_hack
+    nop
+
+@@bonks_kill:
+    sh      $zero, 0x30(t8)  ; Player Health
+
+@@cmg_entrance_hack:
+    lh      t3, 0x30(t8)                ; Skip scene check if player will survive the damage
+    bnez    t3, @@return_bonk
+    nop
+    la      t7, GLOBAL_CONTEXT          ; Only change flags if we're in the Treasure Box Shop
+    lh      t3, 0x00A4(t7)              ; current scene number
+    li      t4, 0x0010                  ; Treasure Box Shop scene number
+    bne     t3, t4, @@return_bonk
+    nop
+    ; Set scene temp flags to zero to re-lock doors
+    sw      $zero, 0x1D2C(t7)
+    ; Chests should be reset on scene load, but just in case
+    sw      $zero, 0x1D38(t7)
+    ; Remove any keys in the player's inventory for Treasure Box Shop
+    sb      $zero, 0x00CC(t8)
+
+@@return_bonk:
+    jr      ra
+    nop
+
+
+KING_DODONGO_BONKS:
+    ; One Bonk KO setting enabled
+    lh      t0, CFG_BONK_DAMAGE
+    addiu   t2, $zero, 0xFFFE
+    bne     t0, t2, @@return_bonk_kd
+    nop
+
+    ; Set King Dodongo health to zero
+    lh      t1, 0x0198(s0)          ; this->numWallCollisions
+    beqz    t1, @@return_bonk_kd
+    nop
+    sh      $zero, 0x0184(s0)       ; this->health
+
+@@return_bonk_kd:
+    ; displaced code
+    lh      t2, 0x0032(s1)
+    mtc1    $zero, $f16
+    jr      ra
+    nop
+
+CHECK_ROOM_MESH_TYPE:
+    ; displaced code
+    sll     a2, v0, 16
+    sra     a2, a2, 16
+
+    ; globalCtx->roomCtx.curRoom
+    lui     $at, 0x0001
+    ori     $at, $at, 0x1CBC
+    addu    t6, a0, $at
+
+    ; room->mesh->polygon.type
+    lw      t7, 0x0008(t6)
+    lbu     t8, 0x0000(t7)
+
+    ; Room mesh type 1 is fixed camera areas
+    ; Room mesh type 2 is follow camera areas
+    ; Room mesh type 0 is ???
+    ori     t7, $zero, 0x0001
+    bne     t7, t8, @@return_death_subcamera
+    nop
+    j       0x8038D5B8 ; skips jal 0x8006B6FC (OnePointCutscene_Init), static location as part of player overlay
+    lw      ra, 0x0024($sp)
+
+@@return_death_subcamera:
+    jr      ra
+    nop

--- a/src/build.asm
+++ b/src/build.asm
@@ -292,6 +292,7 @@ RANDO_CONTEXT:
 .include "every_frame.asm"
 .include "dpad.asm"
 .include "initial_save.asm"
+.include "bonk.asm"
 
 .align 0x10
 .importobj "../build/bundle.o"

--- a/src/hacks.asm
+++ b/src/hacks.asm
@@ -107,3 +107,93 @@ Gameplay_InitSkybox:
     nop
     nop
     nop
+
+;==================================================================================================
+; Roll Collision / Bonks Kill Player
+;==================================================================================================
+
+; Set player health to zero on last frame of bonk animation
+; z_player func_80844708, conditional where this->unk_850 != 0 and temp >= 0 || sp44
+; Replaces:
+;   or      a0, s0, $zero
+;   jal     func_80838178
+;   lw      a1, 0x0054($sp)
+;   b       lbl_80842AE8
+;   lw      $ra, 0x0024($sp)
+;   lwc1    $f4, 0x0828(s0)
+;   mtc1    $at, $f6
+;   nop
+.orga 0xBE0228
+; Load APPLY_BONK_DAMAGE address as throwaway instructions. Replacing the jump call causes
+; problems when overlay relocation is applied, breaking both replacement jump calls and nop'ing
+; the instruction. By chance, these two instructions (equivalent to `la APPLY_BONK_DAMAGE`) do
+; not crash after relocation, and so are kept here even though they do nothing.
+    lui     t8, 0x8040
+    addiu   t8, t8, 0x2D04
+; Replace original function call with hook to apply damage if the setting is on.
+; The original function is called in the new function before applying damage.
+; Since the player actor always ends up in the same location in RAM, the jump
+; address there is hardcoded.
+    jal     BONK_LAST_FRAME
+    lw      a1, 0x0054($sp)
+; The branch address is shifted to an alternate location where lw $ra... is run.
+; Required as la t8, APPLY_BONK_DAMAGE gets expanded to two commands.
+    b       0xBE0494
+    lw      $ra, 0x0024($sp)
+    lwc1    $f4, 0x0828(s0)
+    mtc1    $at, $f6
+
+; Prevent set and reset of player state3 flag 4, which is re-used for storing bonk state if the
+; player manages to cancel the roll/bonk animation before the last frame.
+; The flag does not appear to be used by the vanilla game.
+; Replaces:
+;   sb      t4, 0x0682(s0)
+.orga 0xBE3798
+    nop
+; Replaces:
+;   sb      t5, 0x0682(s0)
+.orga 0xBE55E4
+    nop
+
+; Hook to set flag if player starts bonk animation
+; Flag is unset on player death
+; Replaces:
+;   or      a0, s0, $zero
+;   addiu   a1, $zero, 0x00FF
+.orga 0xBE035C
+    jal     SET_BONK_FLAG
+    nop
+
+; Hook into Player_UpdateCommon to check if bonk animation was canceled.
+; If so, kill the dirty cheater.
+; Replaces:
+;   addiu   $at, $zero, 0x0002
+;   lui     t1, 0x8012
+.orga 0xBE5328
+    jal     CHECK_FOR_BONK_CANCEL
+    nop
+
+; Hook to Game Over cutscene init in Player actor to prevent adding a subcamera
+; in scenes with fixed cameras like Link's House or outside Temple of Time.
+; The game crashes in these areas if the cutscene subcamera to rotate around
+; Link as he dies is added.
+; Replaces
+;   sll     a2, v0, 16
+;   sra     a2, a2, 16
+.orga 0xBD200C
+    jal     CHECK_ROOM_MESH_TYPE
+    nop
+
+;==================================================================================================
+; Roll Collision / Bonks Kills King Dodongo
+;==================================================================================================
+
+; King Dodongo tracks the number of wall hits when rolling in order to transition from
+; the rolling animation to walking. Add a hook to the actor update function to check
+; this variable and set actor health to zero if bonks are not zero.
+; Replaces:
+;   lh      t2, 0x0032(s1)
+;   mtc1    $zero, $f16
+.orga 0xC3DC04
+    jal     KING_DODONGO_BONKS
+    nop


### PR DESCRIPTION
Add bonk one hit KO (written by mracsys and contributed to randomizer). The code is identical, except for the fact that the player actor is moved in BQ -- 2 addresses needed to be updated in bonk.asm.